### PR TITLE
Ignore empty users

### DIFF
--- a/lib/lita/handlers/greet.rb
+++ b/lib/lita/handlers/greet.rb
@@ -2,7 +2,7 @@ module Lita
   module Handlers
     class Greet < Handler
 
-      route(/^(hello|hi|good morning|howdy|yo!?$|hey).*/i, :say_hello)
+      route(/^(hello|hi|good morning|howdy|yo!?$|hey) .*/i, :say_hello)
       route(/^welcome (.+)/i, :welcome)
 
       def say_hello(response)

--- a/lib/lita/handlers/greet.rb
+++ b/lib/lita/handlers/greet.rb
@@ -4,8 +4,9 @@ module Lita
 
       route(/^(hello|hi|good morning|howdy|yo!?$|hey).*/i, :say_hello)
       route(/^welcome (.+)/i, :welcome)
-    
+
       def say_hello(response)
+        return if response.user.name.empty?
         reply_to_name = response.user.metadata['mention_name'].nil? ?
                          "#{response.user.name}" :
                         "#{response.user.metadata['mention_name']}"

--- a/spec/lita/handlers/greet_spec.rb
+++ b/spec/lita/handlers/greet_spec.rb
@@ -13,4 +13,10 @@ describe Lita::Handlers::Greet, lita_handler: true do
     send_message("Hi")
     expect(replies.last).to match(/Hello/)
   end
+
+  it "does not send a message when the user object is empty" do
+    user = Lita::User.create("1", name: "")
+    send_message("Hi", as: user)
+    expect(replies.last).not_to match(/Hello/)
+  end
 end


### PR DESCRIPTION
Lita-greet also responds to bots (for example Trello in which a comment contains
Hi). This code makes sure we only reply to a user when they are known in the
Lita database (i.e. real users)