### PR TITLE
fixed infinite recursion bug; added many more greeting types with tests

### DIFF
--- a/lib/lita/handlers/greet.rb
+++ b/lib/lita/handlers/greet.rb
@@ -2,12 +2,12 @@ module Lita
   module Handlers
     class Greet < Handler
 
-      route(/^(ahoy|good (morning|afternoon|evening|night|nite)|greetings|hello|hey|hi!?(| .*)$|howdy|sup|yo!?$).*/i, :say_hello)
+      route(/^(((ahoy|he+l{2,}+o+|he+y+|hi+)+( there)*)|go{2,}d (morning|afternoon|evening|night|nite)|greetings|howdy|sup|yo)+[!1?]*((\s)+Regexp.new(robot.config.robot.name))*[!1?]*$/i, :say_hello)
       route(/^welcome (.+)/i, :welcome)
 
       def say_hello(response)
         return if response.user.name.empty?
-        bot_response = response.message.body.gsub(/[?!]+/, "").gsub(/ #{robot.name}/i, "")
+        bot_response = response.message.body.gsub(/[1?!]+/, "").gsub(/(\s)*#{robot.config.robot.name}(\s)*/i, "")
         response.reply "#{bot_response} #{(response.user.mention_name || response.user.name)}"
       end
 

--- a/spec/lita/handlers/greet_spec.rb
+++ b/spec/lita/handlers/greet_spec.rb
@@ -1,19 +1,19 @@
 require "spec_helper"
 
 describe Lita::Handlers::Greet, lita_handler: true do
-  it { is_expected.to route("hello dog").to(:say_hello) }
-  it { is_expected.to route("hi dog").to(:say_hello) }
+  it { is_expected.to route("hello").to(:say_hello) }
+  it { is_expected.to route("hi there").to(:say_hello) }
   it { is_expected.to route("yo!").to(:say_hello) }
-  it { is_expected.to route("hey bot").to(:say_hello) }
-  it { is_expected.to route("greetings chatbot").to(:say_hello) }
-  it { is_expected.to route("good morning").to(:say_hello) }
+  it { is_expected.to route("heeeyyyy").to(:say_hello) }
+  it { is_expected.to route("greetings").to(:say_hello) }
+  it { is_expected.to route("gooooooooood morning").to(:say_hello) }
   it { is_expected.to route("good afternoon").to(:say_hello) }
-  it { is_expected.to route("good evening").to(:say_hello) }
-  it { is_expected.to route("good night").to(:say_hello) }
-  it { is_expected.to route("good nite").to(:say_hello) }
+  it { is_expected.to route("Good evening").to(:say_hello) }
+  it { is_expected.to route("good night!").to(:say_hello) }
+  it { is_expected.to route("Good Nite").to(:say_hello) }
   it { is_expected.to route("howdy").to(:say_hello) }
-  it { is_expected.to route("sup").to(:say_hello) }
-  it { is_expected.to route("ahoy").to(:say_hello) }
+  it { is_expected.to route("sup!").to(:say_hello) }
+  it { is_expected.to route("ahoy there").to(:say_hello) }
 
   it { is_expected.to route("welcome John Doe").to(:welcome) }
 
@@ -23,7 +23,7 @@ describe Lita::Handlers::Greet, lita_handler: true do
   end
 
   it "sends good morning back to the user name (since no mention_name is supplied) who greeted it" do
-    user = Lita::User.create("1", name: "Stephen")    
+    user = Lita::User.create("1", name: "Stephen")
     send_message("Good morning!", as: user)
     expect(replies.last).to match(/Good morning Stephen/)
   end


### PR DESCRIPTION
There was an infinite recursion bug when someone sent the robot's name in its greeting, causing the robot to go into a feedback loop, but I think I fixed it. I also added a bunch more variations on the kinds of greetings people can send (with tests for them).
